### PR TITLE
Add a service /rosarnl_node/make_plan to return a path to a given point

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_message_files(
 add_service_files(
   FILES
   LoadMapFile.srv
+  MakePlan.srv
 )
 
 add_action_files(

--- a/rosarnl_node.cpp
+++ b/rosarnl_node.cpp
@@ -52,10 +52,10 @@ class RosArnlNode
 
     ArFunctorC<RosArnlNode> myPublishCB;
 
-    ArPose rosPoseToArPose(const geometry_msgs::Pose& p);
-    ArPose rosPoseToArPose(const geometry_msgs::PoseStamped& p) { return rosPoseToArPose(p.pose); }
-    ArPoseWithTime rosPoseStampedToArPoseWithTime(const geometry_msgs::PoseStamped& p); 
-    geometry_msgs::Pose rosPoseToArPose(const ArPose& arpose);
+    static ArPose rosPoseToArPose(const geometry_msgs::Pose& p);
+    static ArPose rosPoseToArPose(const geometry_msgs::PoseStamped& p) { return rosPoseToArPose(p.pose); }
+    static ArPoseWithTime rosPoseStampedToArPoseWithTime(const geometry_msgs::PoseStamped& p);
+    static geometry_msgs::Pose arPoseToRosPose(const ArPose& arpose);
 
     ros::ServiceServer enable_srv;
     ros::ServiceServer disable_srv;
@@ -629,7 +629,8 @@ ArPose RosArnlNode::rosPoseToArPose(const geometry_msgs::Pose& p)
   return ArPose( p.position.x * 1000.0, p.position.y * 1000.0, tf::getYaw(p.orientation) / (M_PI/180.0) );
 }
 
-geometry_msgs::Pose arPoseToRosPose(const ArPose& arpose)
+
+geometry_msgs::Pose RosArnlNode::arPoseToRosPose(const ArPose& arpose)
 {
   // TODO use tf::poseTFToMsg instead?
   geometry_msgs::Pose rospose;

--- a/srv/MakePlan.srv
+++ b/srv/MakePlan.srv
@@ -1,0 +1,3 @@
+geometry_msgs/Pose goal
+---
+geometry_msgs/Pose[] path


### PR DESCRIPTION
I want to calculate the travel distance to different points of interest, so I've added a service that returns a path from the robot to a given pose, without making the robot go there.
It's essentially the same as make_plan from move_base (http://wiki.ros.org/move_base#Services)

The forward declaration of arPoseToRosPose was missing, so I've added it. To use it in the call to std::transform it had to be static. I made the other pose transform methods static while I was at it.